### PR TITLE
Add skin support for DoiteAuras and advancedtradeskills2 addon

### DIFF
--- a/pfUI-addonskinner.toc
+++ b/pfUI-addonskinner.toc
@@ -14,6 +14,7 @@ pfUI-addonskinner-gui.lua
 
 # skins
 skins\AdvancedTradeskillWindow.lua
+skins\AdvancedTradeSkillWindow2.lua
 skins\Artisan.lua
 skins\Atlas.lua
 skins\AtlasLoot.lua
@@ -27,6 +28,7 @@ skins\Clique.lua
 skins\CloseUP.lua
 skins\ColorPickerPlus.lua
 skins\Decursive.lua
+skins\DoiteAuras.lua
 skins\EQL3.lua
 skins\ES_GuildCheckGUI.lua
 skins\GearMenu.lua

--- a/skins/AdvancedTradeSkillWindow2.lua
+++ b/skins/AdvancedTradeSkillWindow2.lua
@@ -1,0 +1,800 @@
+pfUI.addonskinner:RegisterSkin("AdvancedTradeSkillWindow2", function()
+  -- Import pfUI environment
+  local penv = pfUI:GetEnvironment()
+  local StripTextures, CreateBackdrop, SkinButton, SkinCheckbox, SkinCloseButton, 
+        SkinTab, SkinScrollbar, SkinArrowButton, SkinDropDown, SkinSlider, 
+        SkinCollapseButton, SetAllPointsOffset, SetHighlight, EnableMovable,
+        HookScript, hooksecurefunc = 
+    penv.StripTextures, penv.CreateBackdrop, penv.SkinButton, penv.SkinCheckbox,
+    penv.SkinCloseButton, penv.SkinTab, penv.SkinScrollbar, penv.SkinArrowButton,
+    penv.SkinDropDown, penv.SkinSlider, penv.SkinCollapseButton,
+    penv.SetAllPointsOffset, penv.SetHighlight, penv.EnableMovable,
+    penv.HookScript, penv.hooksecurefunc
+
+  -- Utility
+  local noop = function() end
+
+  -- ============================================
+  -- MAIN FRAME
+  -- ============================================
+  ATSWFrame:DisableDrawLayer("BACKGROUND")
+  StripTextures(ATSWFrame, true)
+  CreateBackdrop(ATSWFrame, nil, nil, .75)
+  ATSWFrame.backdrop:SetAllPoints(ATSWFrame)
+  
+  -- Portrait and Title
+  if ATSWFramePortrait then
+    ATSWFramePortrait:SetAlpha(0)
+  end
+  -- Don't reposition title - it's at TOP of ATSWFrame, y=-17 originally
+  
+  -- Close button
+  SkinCloseButton(ATSWFrameCloseButton, ATSWFrame.backdrop, -6, -6)
+  
+  -- Don't call EnableMovable - addon handles this itself
+
+  -- Strip all background textures
+  local bgTextures = {
+    "ATSWScrollBackgroundTop",
+    "ATSWScrollBackgroundMiddle", 
+    "ATSWScrollBackgroundBottom",
+    "ATSWHorizontalBar1Left",
+    "ATSWHorizontalBar1LeftAddon",
+    "ATSWHorizontalBar2Left",
+    "ATSWHorizontalBar2LeftAddon",
+    "ATSWParchment",
+    "ATSWWeb",
+    "ATSWBackground",
+    "ATSWBackgroundShadow"
+  }
+  
+  for _, texName in ipairs(bgTextures) do
+    local tex = getglobal(texName)
+    if tex then
+      tex:SetTexture(nil)
+      tex:SetAlpha(0)
+    end
+  end
+
+  -- ============================================
+  -- RANK BAR / SKILL LEVEL BAR
+  -- ============================================
+  if ATSWRankFrame then
+    StripTextures(ATSWRankFrame)
+    if ATSWRankFrameBorder then
+      StripTextures(ATSWRankFrameBorder)
+    end
+    ATSWRankFrame:SetStatusBarTexture("Interface\\AddOns\\pfUI\\img\\bar")
+    ATSWRankFrame:SetHeight(12)
+    -- Don't reposition - the Lua code handles position dynamically
+    CreateBackdrop(ATSWRankFrame)
+  end
+
+  -- ============================================
+  -- SORT RADIO BUTTONS (Keep original positioning)
+  -- ============================================
+  local sortButtons = {
+    "ATSWCategorySortCheckbox",
+    "ATSWDifficultySortCheckbox", 
+    "ATSWNameSortCheckbox",
+    "ATSWCustomSortCheckbox"
+  }
+  
+  for _, btnName in ipairs(sortButtons) do
+    local btn = getglobal(btnName)
+    if btn then
+      SkinCheckbox(btn, 20)
+    end
+  end
+  
+  -- DON'T reposition - let them stay in original positions
+  -- Original positions from XML:
+  -- Category: TOPLEFT ATSWFrame x=142 y=-33
+  -- Difficulty: LEFT of Category + 72
+  -- Name: LEFT of Difficulty + 72  
+  -- Custom: LEFT of Name + 63
+
+  -- ============================================
+  -- DROPDOWNS (Keep original positioning)
+  -- ============================================
+  if ATSWSubClassDropDown then
+    StripTextures(ATSWSubClassDropDown)
+    SkinDropDown(ATSWSubClassDropDown)
+    -- Original: TOPLEFT x=427 y=-40 (don't move it)
+  end
+  
+  if ATSWInvSlotDropDown then
+    StripTextures(ATSWInvSlotDropDown)
+    SkinDropDown(ATSWInvSlotDropDown)
+    -- Original: LEFT of SubClass, RIGHT, x=-27 y=0 (don't move it)
+  end
+
+  -- ============================================
+  -- SEARCH BOX AND BUTTONS (Keep original positioning)
+  -- ============================================
+  if ATSWSearchBox then
+    StripTextures(ATSWSearchBox, true, "BACKGROUND")
+    CreateBackdrop(ATSWSearchBox, nil, true)
+    ATSWSearchBox:SetHeight(20)
+    -- Original: TOPLEFT x=75 y=-51 (don't move it)
+    
+    -- Hide search icon if exists
+    if ATSWSearchIcon then
+      ATSWSearchIcon:SetAlpha(0)
+    end
+  end
+  
+  if ATSWSearchBoxClear then
+    SkinButton(ATSWSearchBoxClear)
+    ATSWSearchBoxClear:SetHeight(20)
+    -- Original: RIGHT of SearchBox, RIGHT, x=-2 y=0 (don't move it)
+  end
+  
+  if ATSWSearchHelpButton then
+    SkinButton(ATSWSearchHelpButton)
+    ATSWSearchHelpButton:SetHeight(20)
+    ATSWSearchHelpButton:SetWidth(20)
+    -- Original: LEFT of SearchBox, RIGHT, x=1 y=0 (don't move it)
+  end
+
+  -- Attributes button (Keep original positioning)
+  if ATSWAttributesButton then
+    SkinCheckbox(ATSWAttributesButton, 20)
+    -- Original: LEFT of SearchHelpButton, RIGHT, x=5 y=0 (don't move it)
+  end
+
+  -- ============================================
+  -- MAIN ACTION BUTTONS (Keep original positioning)
+  -- ============================================
+  local mainButtons = {
+    "ATSWCreateButton",      -- BOTTOMRIGHT of Frame, x=-42 y=18
+    "ATSWTaskButton",        -- RIGHT of CreateButton, LEFT, x=0 y=-0.5
+    "ATSWReagentsButton",    -- BOTTOM of Frame, BOTTOM, x=9 y=19.5
+    "ATSWCustomEditorButton", -- TOPLEFT of CustomSort, BOTTOMLEFT, x=0 y=4
+    "ATSWProgressBarStop"
+  }
+  
+  for _, btnName in ipairs(mainButtons) do
+    local btn = getglobal(btnName)
+    if btn then
+      SkinButton(btn)
+      -- Don't reposition - they're already correctly anchored
+    end
+  end
+
+  -- ============================================
+  -- AMOUNT CONTROLS (Keep original relative positioning)
+  -- ============================================
+  if ATSWIncrementButton then
+    SkinArrowButton(ATSWIncrementButton, "right", 16)
+    -- Original: RIGHT of TaskButton, LEFT, x=-1 y=-0.5 (don't move it)
+  end
+  
+  if ATSWAmountBox then
+    StripTextures(ATSWAmountBox, true, "BACKGROUND")
+    CreateBackdrop(ATSWAmountBox, nil, true)
+    ATSWAmountBox:SetHeight(20)
+    ATSWAmountBox:SetWidth(42)
+    -- Original: RIGHT of IncrementButton, LEFT, x=2 y=0.5 (don't move it)
+  end
+  
+  if ATSWDecrementButton then
+    SkinArrowButton(ATSWDecrementButton, "left", 16)
+    -- Original: RIGHT of AmountBox, LEFT, x=-3 y=-0.5 (don't move it)
+  end
+
+  -- ============================================
+  -- RECIPE ICON
+  -- ============================================
+  if ATSWRecipeIcon then
+    StripTextures(ATSWRecipeIcon)
+    SkinButton(ATSWRecipeIcon, nil, nil, nil, nil, true)
+    local iconTex = ATSWRecipeIcon:GetNormalTexture()
+    if iconTex then
+      iconTex:SetTexCoord(.08, .92, .08, .92)
+    end
+  end
+
+  -- Previous item button
+  if ATSWPreviousItemButton then
+    SkinButton(ATSWPreviousItemButton)
+  end
+
+  -- ============================================
+  -- REAGENT SLOTS (Dynamic)
+  -- ============================================
+  for i = 1, 8 do
+    local btn = getglobal("ATSWReagent" .. i)
+    if btn then
+      local btnIcon = getglobal("ATSWReagent" .. i .. "IconTexture")
+      local btnCount = getglobal("ATSWReagent" .. i .. "Count")
+      local btnName = getglobal("ATSWReagent" .. i .. "Name")
+      
+      StripTextures(btn)
+      CreateBackdrop(btn, nil, nil, .75)
+      SetAllPointsOffset(btn.backdrop, btn, 4)
+      SetHighlight(btn)
+      
+      if btnIcon then
+        local size = btn:GetHeight() - 10
+        btnIcon:SetWidth(size)
+        btnIcon:SetHeight(size)
+        btnIcon:ClearAllPoints()
+        btnIcon:SetPoint("LEFT", 5, 0)
+        btnIcon:SetTexCoord(.08, .92, .08, .92)
+        btnIcon:SetParent(btn.backdrop)
+        btnIcon:SetDrawLayer("OVERLAY")
+      end
+      
+      if btnCount then
+        btnCount:SetParent(btn.backdrop)
+        btnCount:SetDrawLayer("OVERLAY")
+        btnCount:ClearAllPoints()
+        btnCount:SetPoint("BOTTOMRIGHT", btnIcon, "BOTTOMRIGHT", 0, 0)
+      end
+      
+      if btnName then
+        btnName:SetParent(btn.backdrop)
+      end
+    end
+  end
+
+  -- ============================================
+  -- RECIPE LIST SCROLL FRAME
+  -- ============================================
+  if ATSWListScrollFrame then
+    StripTextures(ATSWListScrollFrame)
+    local scrollBar = getglobal("ATSWListScrollFrameScrollBar")
+    if scrollBar then
+      SkinScrollbar(scrollBar)
+    end
+    
+    -- Hook OnShow to ensure scrollbar is always skinned
+    HookScript(ATSWListScrollFrame, "OnShow", function()
+      local sb = getglobal("ATSWListScrollFrameScrollBar")
+      if sb and not sb.pfui_skinned then
+        SkinScrollbar(sb)
+        sb.pfui_skinned = true
+      end
+    end)
+  end
+
+  -- Expand button frame
+  if ATSWExpandButtonFrame then
+    StripTextures(ATSWExpandButtonFrame)
+  end
+
+  -- Highlight frames (these are Frame objects, not Texture objects)
+  if ATSWHighlight then
+    StripTextures(ATSWHighlight)
+  end
+  if ATSWHighlightMouseOver then
+    StripTextures(ATSWHighlightMouseOver)
+  end
+
+  -- ============================================
+  -- TASK SCROLL FRAME
+  -- ============================================
+  if ATSWTaskScrollFrameBackground then
+    StripTextures(ATSWTaskScrollFrameBackground)
+  end
+  
+  if ATSWTaskScrollFrame then
+    StripTextures(ATSWTaskScrollFrame)
+    
+    -- Function to skin the scrollbar
+    local function SkinTaskScrollBar()
+      -- Try multiple ways to get the scrollbar
+      local scrollBar = getglobal("ATSWTaskScrollFrameScrollBar")
+      if not scrollBar then
+        scrollBar = ATSWTaskScrollFrame.ScrollBar
+      end
+      if not scrollBar then
+        -- Check children
+        local children = {ATSWTaskScrollFrame:GetChildren()}
+        for i = 1, table.getn(children) do
+          local child = children[i]
+          if child and child:GetObjectType() == "Slider" then
+            scrollBar = child
+            break
+          end
+        end
+      end
+      
+      if scrollBar and not scrollBar.pfui_skinned then
+        SkinScrollbar(scrollBar)
+        scrollBar.pfui_skinned = true
+        return true
+      end
+      return false
+    end
+    
+    -- Try immediately
+    SkinTaskScrollBar()
+    
+    -- Hook OnShow
+    HookScript(ATSWTaskScrollFrame, "OnShow", function()
+      SkinTaskScrollBar()
+    end)
+    
+    -- Also check when tasks are updated
+    hooksecurefunc("ATSW_UpdateTasks", function()
+      SkinTaskScrollBar()
+    end, true)
+  end
+
+  -- ============================================
+  -- PROGRESS BAR
+  -- ============================================
+  if ATSWProgressBar then
+    StripTextures(ATSWProgressBar)
+    ATSWProgressBar:SetStatusBarTexture("Interface\\AddOns\\pfUI\\img\\bar")
+    CreateBackdrop(ATSWProgressBar)
+  end
+  
+  if ATSWProgressBarBorder then
+    StripTextures(ATSWProgressBarBorder)
+  end
+
+  -- ============================================
+  -- TRAINING POINTS FRAME
+  -- ============================================
+  if ATSWTrainingPointsFrame then
+    StripTextures(ATSWTrainingPointsFrame)
+  end
+
+  -- ============================================
+  -- SIDE TABS (Dynamically Created) - SIMPLIFIED APPROACH
+  -- ============================================
+  
+  -- Simple function that just skins without interfering
+  local function SkinSideTab(tab)
+    if not tab or tab.pfui_skinned then return end
+    
+    -- Remove spellbook background texture (in BACKGROUND layer)
+    local regions = {tab:GetRegions()}
+    for i = 1, table.getn(regions) do
+      local region = regions[i]
+      if region and region:GetObjectType() == "Texture" and region:GetDrawLayer() == "BACKGROUND" then
+        region:SetTexture(nil)
+      end
+    end
+    
+    -- Create backdrop BEHIND the button, not on top
+    CreateBackdrop(tab, nil, nil, .75)
+    if tab.backdrop then
+      tab.backdrop:SetFrameLevel(tab:GetFrameLevel() - 1)  -- Put backdrop BEHIND tab
+      tab.backdrop:EnableMouse(false)  -- Backdrop shouldn't intercept clicks
+    end
+    
+    SetHighlight(tab)
+    
+    -- Make sure the tab itself can receive clicks
+    tab:EnableMouse(true)
+    tab:SetFrameLevel(tab:GetParent():GetFrameLevel() + 2)  -- Above parent and backdrop
+    
+    -- The addon sets NormalTexture - we just need to crop it
+    -- Do this via a repeating check since addon may set it later
+    local function UpdateTabIcon()
+      local tex = tab:GetNormalTexture()
+      if tex then
+        tex:SetTexCoord(.08, .92, .08, .92)
+        tex:SetDrawLayer("ARTWORK")
+      end
+    end
+    
+    -- Apply immediately
+    UpdateTabIcon()
+    
+    -- Store original OnShow if exists
+    local origOnShow = tab:GetScript("OnShow")
+    
+    -- Apply on show
+    tab:SetScript("OnShow", function()
+      if origOnShow then origOnShow() end
+      UpdateTabIcon()
+    end)
+    
+    tab.pfui_skinned = true
+  end
+  
+  -- Skin all tabs immediately
+  for i = 1, 20 do
+    local tab = getglobal("ATSWFrameTab" .. i)
+    if tab then
+      SkinSideTab(tab)
+    end
+  end
+  
+  -- Update tab icons periodically when frame is shown
+  local tabUpdateFrame = CreateFrame("Frame")
+  tabUpdateFrame:SetScript("OnUpdate", function()
+    if ATSWFrame:IsVisible() then
+      for i = 1, 20 do
+        local tab = getglobal("ATSWFrameTab" .. i)
+        if tab and tab:IsVisible() then
+          -- Ensure clickability
+          if not tab.clickabilityChecked then
+            tab:EnableMouse(true)
+            tab:SetFrameLevel(tab:GetParent():GetFrameLevel() + 2)
+            tab.clickabilityChecked = true
+          end
+          
+          -- Update icon cropping
+          local tex = tab:GetNormalTexture()
+          if tex then
+            tex:SetTexCoord(.08, .92, .08, .92)
+          end
+        end
+      end
+    end
+  end)
+
+  -- ============================================
+  -- DYNAMICALLY CREATED RECIPE BUTTONS
+  -- ============================================
+  local function SkinRecipeButton(button)
+    if button and not button.pfui_skinned then
+      StripTextures(button)
+      local icon = getglobal(button:GetName() .. "Icon")
+      if icon then
+        icon:SetTexCoord(.08, .92, .08, .92)
+      end
+      button.pfui_skinned = true
+    end
+  end
+  
+  hooksecurefunc("ATSW_CreateRecipeButtons", function()
+    for i = 1, 30 do
+      local btn = getglobal("ATSWRecipe" .. i)
+      if btn then
+        SkinRecipeButton(btn)
+      end
+    end
+  end, true)
+  
+  -- Skin existing recipe buttons
+  for i = 1, 30 do
+    local btn = getglobal("ATSWRecipe" .. i)
+    if btn then
+      SkinRecipeButton(btn)
+    end
+  end
+
+  -- ============================================
+  -- DYNAMICALLY CREATED TOOL BUTTONS
+  -- ============================================
+  local function SkinToolButton(button)
+    if button and not button.pfui_skinned then
+      StripTextures(button)
+      local icon = getglobal(button:GetName() .. "Icon")
+      if icon then
+        icon:SetTexCoord(.08, .92, .08, .92)
+      end
+      button.pfui_skinned = true
+    end
+  end
+  
+  hooksecurefunc("ATSW_CreateToolButtons", function()
+    for i = 1, 10 do
+      local btn = getglobal("ATSWTool" .. i)
+      if btn then
+        SkinToolButton(btn)
+      end
+    end
+  end, true)
+
+  -- ============================================
+  -- DYNAMICALLY CREATED TASK BUTTONS
+  -- ============================================
+  local function SkinTaskButton(button)
+    if button and not button.pfui_skinned then
+      StripTextures(button)
+      local deleteBtn = getglobal(button:GetName() .. "DeleteButton")
+      if deleteBtn then
+        SkinCloseButton(deleteBtn)
+      end
+      button.pfui_skinned = true
+    end
+  end
+  
+  hooksecurefunc("ATSW_CreateTaskButtons", function()
+    for i = 1, 10 do
+      local btn = getglobal("ATSWTask" .. i)
+      if btn then
+        SkinTaskButton(btn)
+      end
+    end
+  end, true)
+
+  -- ============================================
+  -- REAGENTS FRAME
+  -- ============================================
+  if ATSWReagentsFrame then
+    StripTextures(ATSWReagentsFrame, true)
+    CreateBackdrop(ATSWReagentsFrame, nil, nil, .75)
+    ATSWReagentsFrame.backdrop:SetAllPoints(ATSWReagentsFrame)
+    
+    if ATSWReagentsFrameCloseButton then
+      SkinCloseButton(ATSWReagentsFrameCloseButton, ATSWReagentsFrame.backdrop, -6, -6)
+    end
+    
+    if ATSWReagentsFrameTitleText then
+      -- Don't reposition - let it stay at original position
+    end
+  end
+
+  -- Skin reagent frame scroll (if exists)
+  local rfScrollFrame = getglobal("ATSWRFScrollFrame")
+  if rfScrollFrame then
+    StripTextures(rfScrollFrame)
+    local scrollBar = getglobal("ATSWRFScrollFrameScrollBar")
+    if scrollBar then
+      SkinScrollbar(scrollBar)
+    end
+  end
+
+  -- ============================================
+  -- CONFIG/OPTIONS FRAME
+  -- ============================================
+  if ATSWConfigFrame then
+    StripTextures(ATSWConfigFrame, true)
+    CreateBackdrop(ATSWConfigFrame, nil, nil, .75)
+    ATSWConfigFrame.backdrop:SetAllPoints(ATSWConfigFrame)
+    
+    -- Hide header texture
+    if ATSWOptionsMenuHeader then
+      ATSWOptionsMenuHeader:SetAlpha(0)
+    end
+  end
+
+  -- Option checkboxes
+  local optionCheckboxes = {
+    "ATSWOFUnifiedButton",
+    "ATSWOFSeparateButton",
+    "ATSWOFIncludeBankButton",
+    "ATSWOFIncludeAltsButton",
+    "ATSWOFIncludeMerchantsButton",
+    "ATSWOFAutoBuyButton",
+    "ATSWOFTooltipButton",
+    "ATSWOFShoppingListButton"
+  }
+  
+  for _, cbName in ipairs(optionCheckboxes) do
+    local cb = getglobal(cbName)
+    if cb then
+      SkinCheckbox(cb, 20)
+    end
+  end
+
+  -- Option frame boxes
+  local optionFrames = {
+    "ATSWOptionsTotalDisplayed",
+    "ATSWOptionsTotalInclude",
+    "ATSWOptionsAddonsCompat",
+    "ATSWOptionsAddonsCompatTable"
+  }
+  
+  for _, frameName in ipairs(optionFrames) do
+    local frame = getglobal(frameName)
+    if frame then
+      StripTextures(frame)
+      CreateBackdrop(frame, nil, nil, .85)
+    end
+  end
+
+  -- OK button for config
+  local configOKBtn = getglobal("ATSWConfigFrameOKButton")
+  if configOKBtn then
+    SkinButton(configOKBtn)
+  end
+
+  -- ============================================
+  -- SEARCH HELP FRAME
+  -- ============================================
+  if ATSWSearchHelpFrame then
+    StripTextures(ATSWSearchHelpFrame, true)
+    CreateBackdrop(ATSWSearchHelpFrame, nil, nil, .75)
+    
+    if ATSWHelpMenuHeader then
+      ATSWHelpMenuHeader:SetAlpha(0)
+    end
+    
+    local helpOKBtn = getglobal("ATSWSearchHelpFrameOKButton")
+    if helpOKBtn then
+      SkinButton(helpOKBtn)
+    end
+  end
+
+  -- ============================================
+  -- SHOPPING LIST FRAME
+  -- ============================================
+  if ATSWShoppingListFrame then
+    StripTextures(ATSWShoppingListFrame, true)
+    CreateBackdrop(ATSWShoppingListFrame, nil, nil, .75)
+    ATSWShoppingListFrame.backdrop:SetAllPoints(ATSWShoppingListFrame)
+    
+    if ATSWShoppingListFrameTitleText then
+      -- Don't reposition - let it stay at original position
+    end
+    
+    local slCloseBtn = getglobal("ATSWShoppingListFrameCloseButton")
+    if slCloseBtn then
+      SkinCloseButton(slCloseBtn, ATSWShoppingListFrame.backdrop, -6, -6)
+    end
+  end
+  
+  if ATSWSLScrollFrame then
+    StripTextures(ATSWSLScrollFrame)
+    local slScrollBar = getglobal("ATSWSLScrollFrameScrollBar")
+    if slScrollBar then
+      SkinScrollbar(slScrollBar)
+    end
+  end
+
+  -- ============================================
+  -- BUY NECESSARY FRAME
+  -- ============================================
+  if ATSWBuyNecessaryFrame then
+    StripTextures(ATSWBuyNecessaryFrame, true)
+    CreateBackdrop(ATSWBuyNecessaryFrame, nil, nil, .75)
+    
+    local buyBtn = getglobal("ATSWBuyButton")
+    if buyBtn then
+      SkinButton(buyBtn)
+    end
+  end
+
+  -- ============================================
+  -- CUSTOM SORTING FRAME (if exists in CustomSorting.xml)
+  -- ============================================
+  if ATSWCSFrame then
+    StripTextures(ATSWCSFrame, true)
+    CreateBackdrop(ATSWCSFrame, nil, nil, .75)
+    ATSWCSFrame.backdrop:SetAllPoints(ATSWCSFrame)
+    
+    local csCloseBtn = getglobal("ATSWCSFrameCloseButton")
+    if csCloseBtn then
+      SkinCloseButton(csCloseBtn, ATSWCSFrame.backdrop, -6, -6)
+    end
+  end
+
+  -- Custom sorting scroll frames
+  if ATSWCSUListScrollFrame then
+    StripTextures(ATSWCSUListScrollFrame)
+    local csScrollBar = getglobal("ATSWCSUListScrollFrameScrollBar")
+    if csScrollBar then
+      SkinScrollbar(csScrollBar)
+    end
+  end
+  
+  if ATSWCSSListScrollFrame then
+    StripTextures(ATSWCSSListScrollFrame)
+    local cssScrollBar = getglobal("ATSWCSSListScrollFrameScrollBar")
+    if cssScrollBar then
+      SkinScrollbar(cssScrollBar)
+    end
+  end
+
+  -- Custom sorting buttons
+  local csButtons = {
+    "ATSWCSButton",
+    "ATSWCSAddButton",
+    "ATSWCSDeleteButton",
+    "ATSWCSUpButton",
+    "ATSWCSDownButton",
+    "ATSWCSOKButton",
+    "ATSWCSCancelButton"
+  }
+  
+  for _, btnName in ipairs(csButtons) do
+    local btn = getglobal(btnName)
+    if btn then
+      SkinButton(btn)
+    end
+  end
+
+  -- ============================================
+  -- ADDITIONAL BUTTONS AND ELEMENTS
+  -- ============================================
+  
+  -- Any dialog boxes
+  if ATSWDialogBoxFrame_OnlyOK then
+    StripTextures(ATSWDialogBoxFrame_OnlyOK, true)
+    CreateBackdrop(ATSWDialogBoxFrame_OnlyOK, nil, nil, .75)
+  end
+
+  -- Compat addon checkmarks
+  for i = 1, 10 do
+    local compatFrame = getglobal("ATSWCompatAddon" .. i)
+    if compatFrame then
+      local installedBtn = getglobal("ATSWCompatAddon" .. i .. "Installed")
+      if installedBtn then
+        StripTextures(installedBtn)
+      end
+    end
+  end
+
+  -- Money frames (if they use templates)
+  local function SkinMoneyFrame(frame)
+    if frame then
+      StripTextures(frame)
+      local goldBtn = getglobal(frame:GetName() .. "GoldButton")
+      local silverBtn = getglobal(frame:GetName() .. "SilverButton")
+      local copperBtn = getglobal(frame:GetName() .. "CopperButton")
+      
+      if goldBtn then StripTextures(goldBtn) end
+      if silverBtn then StripTextures(silverBtn) end
+      if copperBtn then StripTextures(copperBtn) end
+    end
+  end
+  
+  -- Skin any money displays
+  if ATSWBuyPrice then
+    SkinMoneyFrame(ATSWBuyPrice)
+  end
+
+  -- ============================================
+  -- HOOK FOR ANY REMAINING DYNAMIC ELEMENTS
+  -- ============================================
+  
+  -- Hook the main update function to catch any late-created elements
+  hooksecurefunc("ATSW_Update", function()
+    -- Check for any unskinned recipe buttons
+    for i = 1, 50 do
+      local btn = getglobal("ATSWRecipe" .. i)
+      if btn and not btn.pfui_skinned then
+        SkinRecipeButton(btn)
+      end
+      
+      local tool = getglobal("ATSWTool" .. i)
+      if tool and not tool.pfui_skinned then
+        SkinToolButton(tool)
+      end
+      
+      local task = getglobal("ATSWTask" .. i)
+      if task and not task.pfui_skinned then
+        SkinTaskButton(task)
+      end
+      
+      local reagent = getglobal("ATSWRFReagent" .. i)
+      if reagent and not reagent.pfui_skinned then
+        StripTextures(reagent)
+        reagent.pfui_skinned = true
+      end
+      
+      local slReagent = getglobal("ATSWSLFReagent" .. i)
+      if slReagent and not slReagent.pfui_skinned then
+        StripTextures(slReagent)
+        slReagent.pfui_skinned = true
+      end
+    end
+  end, true)
+
+  -- ============================================
+  -- FINAL CLEANUP
+  -- ============================================
+  
+  -- Hide any remaining Blizzard UI textures we might have missed
+  HookScript(ATSWFrame, "OnShow", function()
+    -- Additional cleanup on show
+    local regions = {ATSWFrame:GetRegions()}
+    for i = 1, table.getn(regions) do
+      local region = regions[i]
+      if region and region:GetObjectType() == "Texture" then
+        local texPath = region:GetTexture()
+        if texPath and (
+          string.find(texPath, "TaxiFrame") or 
+          string.find(texPath, "DialogBox") or
+          string.find(texPath, "Parchment") or
+          string.find(texPath, "ClassTrainer")
+        ) then
+          region:SetTexture(nil)
+          region:SetAlpha(0)
+        end
+      end
+    end
+  end)
+
+  pfUI.addonskinner:UnregisterSkin("AdvancedTradeSkillWindow2")
+end)

--- a/skins/DoiteAuras.lua
+++ b/skins/DoiteAuras.lua
@@ -1,0 +1,452 @@
+pfUI.addonskinner:RegisterSkin("DoiteAuras", function()
+  -- Import pfUI environment
+  local penv = pfUI:GetEnvironment()
+  local StripTextures = penv.StripTextures
+  local CreateBackdrop = penv.CreateBackdrop
+  local SkinButton = penv.SkinButton
+  local SkinCheckbox = penv.SkinCheckbox
+  local SkinCloseButton = penv.SkinCloseButton
+  local SkinScrollbar = penv.SkinScrollbar
+  local SkinDropDown = penv.SkinDropDown
+  local SkinSlider = penv.SkinSlider
+  
+  -- ============================================
+  -- MAIN DOITEAURAS FRAME (DoiteAuras.lua)
+  -- ============================================
+  local function SkinMainFrame()
+    local mainFrame = getglobal("DoiteAurasFrame")
+    if mainFrame and not mainFrame.pfui_skinned then
+      StripTextures(mainFrame, true)
+      CreateBackdrop(mainFrame, nil, nil, .75)
+      mainFrame.backdrop:SetAllPoints(mainFrame)
+      
+      -- Skin named buttons
+      local btns = {"DoiteAurasExportButton", "DoiteAurasImportButton", "DoiteAurasSettingsButton", "DoiteAurasAddBtn"}
+      for _, btnName in ipairs(btns) do
+        local btn = getglobal(btnName)
+        if btn then SkinButton(btn) end
+      end
+      
+      -- Skin unnamed buttons (close button and test all button)
+      local children = {mainFrame:GetChildren()}
+      for i = 1, table.getn(children) do
+        local child = children[i]
+        if child and child:GetObjectType() == "Button" and not child:GetName() then
+          -- Check if it's the close button (TOPRIGHT) or test all (BOTTOMLEFT)
+          local point = child:GetPoint(1)
+          if point == "TOPRIGHT" then
+            SkinCloseButton(child, mainFrame.backdrop, -6, -6)
+          else
+            SkinButton(child)  -- Test All button
+          end
+        elseif child and child:GetObjectType() == "CheckButton" then
+          SkinCheckbox(child, 20)
+        end
+      end
+      
+      -- Skin dropdowns - use SkinDropDown
+      local dropdowns = {"DoiteAurasAbilityDropDown", "DoiteAurasItemDropDown", "DoiteAurasBarDropDown"}
+      for _, ddName in ipairs(dropdowns) do
+        local dd = getglobal(ddName)
+        if dd then
+          StripTextures(dd)
+          SkinDropDown(dd)
+        end
+      end
+      
+      -- Skin input box
+      local input = getglobal("DoiteAurasInput")
+      if input then
+        StripTextures(input, true, "BACKGROUND")
+        CreateBackdrop(input, nil, true)
+      end
+      
+      -- Skin scrollbar
+      local scrollBar = getglobal("DoiteAurasScrollScrollBar")
+      if scrollBar then SkinScrollbar(scrollBar) end
+      
+      mainFrame.pfui_skinned = true
+    end
+    
+    -- Skin dynamic list elements
+    local listContent = getglobal("DoiteAurasListContent")
+    if listContent then
+      local listChildren = {listContent:GetChildren()}
+      for i = 1, table.getn(listChildren) do
+        local row = listChildren[i]
+        if row then
+          if row.editBtn and not row.editBtn.pfui_skinned then
+            SkinButton(row.editBtn)
+            row.editBtn.pfui_skinned = true
+          end
+          if row.removeBtn and not row.removeBtn.pfui_skinned then
+            SkinButton(row.removeBtn)
+            row.removeBtn.pfui_skinned = true
+          end
+          if row.upBtn and not row.upBtn.pfui_skinned then
+            CreateBackdrop(row.upBtn, nil, nil, .75)
+            if row.upBtn.backdrop then
+              row.upBtn.backdrop:SetAllPoints(row.upBtn)
+              row.upBtn.backdrop:SetFrameLevel(row.upBtn:GetFrameLevel() - 1)
+            end
+            local tex = row.upBtn:GetNormalTexture()
+            if tex then tex:SetTexCoord(.2, .8, .2, .8) end
+            row.upBtn.pfui_skinned = true
+          end
+          if row.downBtn and not row.downBtn.pfui_skinned then
+            CreateBackdrop(row.downBtn, nil, nil, .75)
+            if row.downBtn.backdrop then
+              row.downBtn.backdrop:SetAllPoints(row.downBtn)
+              row.downBtn.backdrop:SetFrameLevel(row.downBtn:GetFrameLevel() - 1)
+            end
+            local tex = row.downBtn:GetNormalTexture()
+            if tex then tex:SetTexCoord(.2, .8, .2, .8) end
+            row.downBtn.pfui_skinned = true
+          end
+          if row.disableCheck and not row.disableCheck.pfui_skinned then
+            SkinCheckbox(row.disableCheck, 14)
+            row.disableCheck.pfui_skinned = true
+          end
+          if row.sortTime and not row.sortTime.pfui_skinned then
+            SkinCheckbox(row.sortTime, 14)
+            row.sortTime.pfui_skinned = true
+          end
+          if row.sortPrio and not row.sortPrio.pfui_skinned then
+            SkinCheckbox(row.sortPrio, 14)
+            row.sortPrio.pfui_skinned = true
+          end
+          if row.fixedCheck and not row.fixedCheck.pfui_skinned then
+            SkinCheckbox(row.fixedCheck, 14)
+            row.fixedCheck.pfui_skinned = true
+          end
+        end
+      end
+    end
+  end
+  
+  -- ============================================
+  -- EDIT FRAME (DoiteEdit.lua - DoiteConditionsFrame)
+  -- ============================================
+  local function SkinEditFrame()
+    local condFrame = getglobal("DoiteConditionsFrame")
+    if condFrame and not condFrame.pfui_skinned then
+      StripTextures(condFrame, true)
+      CreateBackdrop(condFrame, nil, nil, .75)
+      condFrame.backdrop:SetAllPoints(condFrame)
+      
+      -- Skin all dropdowns
+      local dropdowns = {
+        "DoiteConditions_GroupDD", "DoiteConditions_GrowthDD", "DoiteConditions_NumAurasDD",
+        "DoiteCond_Ability_GroupingDD", "DoiteCond_Ability_DistanceDD", "DoiteCond_Ability_UnitTypeDD",
+        "DoiteCond_Ability_SliderDir", "DoiteCond_Ability_WeaponDD", "DoiteCond_Ability_FormDD",
+        "DoiteCond_Aura_GroupingDD", "DoiteCond_Aura_DistanceDD", "DoiteCond_Aura_UnitTypeDD",
+        "DoiteCond_Aura_WeaponDD", "DoiteCond_Aura_FormDD", "DoiteCond_Item_GroupingDD",
+        "DoiteCond_Item_Enchant", "DoiteCond_Item_DistanceDD", "DoiteCond_Item_UnitTypeDD",
+        "DoiteCond_Item_WeaponDD", "DoiteCond_Item_FormDD", "DoiteCond_Category_Dropdown"
+      }
+      for _, ddName in ipairs(dropdowns) do
+        local dd = getglobal(ddName)
+        if dd then
+          StripTextures(dd)
+          SkinDropDown(dd)
+        end
+      end
+      
+      -- Skin sliders
+      local sliders = {
+        "DoiteConditions_SpacingSlider",
+        "DoiteConditions_SliderX",
+        "DoiteConditions_SliderY",
+        "DoiteConditions_SliderSize"
+      }
+      for _, sliderName in ipairs(sliders) do
+        local slider = getglobal(sliderName)
+        if slider then SkinSlider(slider) end
+      end
+      
+      -- Skin grid button
+      local gridBtn = getglobal("DoiteConditions_GridBtn")
+      if gridBtn then SkinButton(gridBtn) end
+      
+      -- Skin checkboxes
+      if condFrame.leaderCB then SkinCheckbox(condFrame.leaderCB, 20) end
+      if condFrame.categoryCheck then SkinCheckbox(condFrame.categoryCheck, 20) end
+      
+      -- Skin edit boxes
+      if condFrame.categoryInput then
+        StripTextures(condFrame.categoryInput, true, "BACKGROUND")
+        CreateBackdrop(condFrame.categoryInput, nil, true)
+      end
+      if condFrame.sliderXBox then
+        StripTextures(condFrame.sliderXBox, true, "BACKGROUND")
+        CreateBackdrop(condFrame.sliderXBox, nil, true)
+      end
+      if condFrame.sliderYBox then
+        StripTextures(condFrame.sliderYBox, true, "BACKGROUND")
+        CreateBackdrop(condFrame.sliderYBox, nil, true)
+      end
+      if condFrame.sliderSizeBox then
+        StripTextures(condFrame.sliderSizeBox, true, "BACKGROUND")
+        CreateBackdrop(condFrame.sliderSizeBox, nil, true)
+      end
+      
+      -- Skin buttons
+      if condFrame.categoryButton then SkinButton(condFrame.categoryButton) end
+      
+      -- Skin dynamic condition row buttons (Ability/Buff/Debuff/Talent conditions)
+      local anchors = {condFrame.abilityAuraAnchor, condFrame.auraAuraAnchor, condFrame.itemAuraAnchor}
+      for _, anchor in ipairs(anchors) do
+        if anchor then
+          local anchorChildren = {anchor:GetChildren()}
+          for i = 1, table.getn(anchorChildren) do
+            local row = anchorChildren[i]
+            if row then
+              -- Skin row buttons
+              if row.btn1 and not row.btn1.pfui_skinned then
+                SkinButton(row.btn1)
+                row.btn1.pfui_skinned = true
+              end
+              if row.btn2 and not row.btn2.pfui_skinned then
+                SkinButton(row.btn2)
+                row.btn2.pfui_skinned = true
+              end
+              if row.btn3 and not row.btn3.pfui_skinned then
+                SkinButton(row.btn3)
+                row.btn3.pfui_skinned = true
+              end
+              if row.closeBtn and not row.closeBtn.pfui_skinned then
+                SkinButton(row.closeBtn)
+                row.closeBtn.pfui_skinned = true
+              end
+              if row.addButton and not row.addButton.pfui_skinned then
+                SkinButton(row.addButton)
+                row.addButton.pfui_skinned = true
+              end
+              -- Skin edit box
+              if row.editBox and not row.editBox.pfui_skinned then
+                StripTextures(row.editBox, true, "BACKGROUND")
+                CreateBackdrop(row.editBox, nil, true)
+                row.editBox.pfui_skinned = true
+              end
+              -- Skin dropdown
+              if row.abilityDD and not row.abilityDD.pfui_skinned then
+                StripTextures(row.abilityDD)
+                SkinDropDown(row.abilityDD)
+                row.abilityDD.pfui_skinned = true
+              end
+            end
+          end
+        end
+      end
+      
+      condFrame.pfui_skinned = true
+    end
+  end
+  
+  -- ============================================
+  -- EXPORT FRAME (DoiteExport.lua)
+  -- ============================================
+  local function SkinExportFrame()
+    local exportFrame = getglobal("DoiteAurasExportFrame")
+    if exportFrame and not exportFrame.pfui_skinned then
+      StripTextures(exportFrame, true)
+      CreateBackdrop(exportFrame, nil, nil, .75)
+      exportFrame.backdrop:SetAllPoints(exportFrame)
+      
+      -- Find close button
+      local children = {exportFrame:GetChildren()}
+      for i = 1, table.getn(children) do
+        local child = children[i]
+        if child and child:GetObjectType() == "Button" and not child:GetName() then
+          SkinCloseButton(child, exportFrame.backdrop, -6, -6)
+          break
+        end
+      end
+      
+      -- Skin scrollbars
+      local scrollBar1 = getglobal("DoiteAurasExportScrollScrollBar")
+      if scrollBar1 then SkinScrollbar(scrollBar1) end
+      local scrollBar2 = getglobal("DoiteAurasExportTextScrollScrollBar")
+      if scrollBar2 then SkinScrollbar(scrollBar2) end
+      
+      -- Skin edit box
+      local editBox = getglobal("DoiteAurasExportEditBox")
+      if editBox then
+        StripTextures(editBox, true, "BACKGROUND")
+        CreateBackdrop(editBox, nil, true)
+      end
+      
+      -- Skin buttons
+      local btns = {"DoiteAurasCreateExportButton", "DoiteAurasClearExportButton", "DoiteAurasCopyExportButton"}
+      for _, btnName in ipairs(btns) do
+        local btn = getglobal(btnName)
+        if btn then SkinButton(btn) end
+      end
+      
+      exportFrame.pfui_skinned = true
+    end
+  end
+  
+  -- ============================================
+  -- IMPORT FRAME (DoiteExport.lua)
+  -- ============================================
+  local function SkinImportFrame()
+    local importFrame = getglobal("DoiteAurasImportFrame")
+    if importFrame and not importFrame.pfui_skinned then
+      StripTextures(importFrame, true)
+      CreateBackdrop(importFrame, nil, nil, .75)
+      importFrame.backdrop:SetAllPoints(importFrame)
+      
+      -- Find close button
+      local children = {importFrame:GetChildren()}
+      for i = 1, table.getn(children) do
+        local child = children[i]
+        if child and child:GetObjectType() == "Button" and not child:GetName() then
+          SkinCloseButton(child, importFrame.backdrop, -6, -6)
+          break
+        end
+      end
+      
+      -- Skin scrollbar
+      local scrollBar = getglobal("DoiteAurasImportScrollScrollBar")
+      if scrollBar then SkinScrollbar(scrollBar) end
+      
+      -- Skin edit box
+      local editBox = getglobal("DoiteAurasImportEditBox")
+      if editBox then
+        StripTextures(editBox, true, "BACKGROUND")
+        CreateBackdrop(editBox, nil, true)
+      end
+      
+      -- Skin button
+      local btn = getglobal("DoiteAurasImportDoButton")
+      if btn then SkinButton(btn) end
+      
+      importFrame.pfui_skinned = true
+    end
+  end
+  
+  -- ============================================
+  -- SETTINGS FRAME (DoiteSettings.lua)
+  -- ============================================
+  local function SkinSettingsFrame()
+    local settingsFrame = getglobal("DoiteAurasSettingsFrame")
+    if settingsFrame and not settingsFrame.pfui_skinned then
+      StripTextures(settingsFrame, true)
+      CreateBackdrop(settingsFrame, nil, nil, .75)
+      settingsFrame.backdrop:SetAllPoints(settingsFrame)
+      
+      -- Skin buttons - first unnamed is close button, rest are regular buttons
+      local children = {settingsFrame:GetChildren()}
+      local unnamedCount = 0
+      for i = 1, table.getn(children) do
+        local child = children[i]
+        if child and child:GetObjectType() == "Button" then
+          if not child:GetName() then
+            unnamedCount = unnamedCount + 1
+            if unnamedCount == 1 then
+              -- First unnamed button is the close button
+              SkinCloseButton(child, settingsFrame.backdrop, -6, -6)
+            else
+              -- Other unnamed buttons are regular buttons (pfUI icons button)
+              SkinButton(child)
+            end
+          else
+            -- Named buttons
+            SkinButton(child)
+          end
+        end
+      end
+      
+      settingsFrame.pfui_skinned = true
+    end
+  end
+  
+  -- ============================================
+  -- IMMEDIATE SKINNING WITH ONSHOW HOOKS
+  -- ============================================
+  
+  -- Hook OnShow for instant skinning
+  local function HookOnShow(frameName, skinFunc)
+    local frame = getglobal(frameName)
+    if frame and not frame.pfui_onshow_hooked then
+      local origOnShow = frame:GetScript("OnShow")
+      frame:SetScript("OnShow", function()
+        if origOnShow then origOnShow() end
+        skinFunc()
+      end)
+      frame.pfui_onshow_hooked = true
+    end
+  end
+  
+  -- Periodic checker
+  local updateFrame = CreateFrame("Frame")
+  updateFrame.elapsed = 0
+  updateFrame:SetScript("OnUpdate", function()
+    this.elapsed = this.elapsed + arg1
+    if this.elapsed > 0.5 then
+      this.elapsed = 0
+      
+      SkinMainFrame()
+      SkinEditFrame()
+      SkinExportFrame()
+      SkinImportFrame()
+      SkinSettingsFrame()
+      
+      -- Also skin dynamic condition rows in edit frame
+      local condFrame = getglobal("DoiteConditionsFrame")
+      if condFrame then
+        local anchors = {condFrame.abilityAuraAnchor, condFrame.auraAuraAnchor, condFrame.itemAuraAnchor}
+        for _, anchor in ipairs(anchors) do
+          if anchor then
+            local anchorChildren = {anchor:GetChildren()}
+            for i = 1, table.getn(anchorChildren) do
+              local row = anchorChildren[i]
+              if row then
+                if row.btn1 and not row.btn1.pfui_skinned then
+                  SkinButton(row.btn1)
+                  row.btn1.pfui_skinned = true
+                end
+                if row.btn2 and not row.btn2.pfui_skinned then
+                  SkinButton(row.btn2)
+                  row.btn2.pfui_skinned = true
+                end
+                if row.btn3 and not row.btn3.pfui_skinned then
+                  SkinButton(row.btn3)
+                  row.btn3.pfui_skinned = true
+                end
+                if row.closeBtn and not row.closeBtn.pfui_skinned then
+                  SkinButton(row.closeBtn)
+                  row.closeBtn.pfui_skinned = true
+                end
+                if row.addButton and not row.addButton.pfui_skinned then
+                  SkinButton(row.addButton)
+                  row.addButton.pfui_skinned = true
+                end
+                if row.editBox and not row.editBox.pfui_skinned then
+                  StripTextures(row.editBox, true, "BACKGROUND")
+                  CreateBackdrop(row.editBox, nil, true)
+                  row.editBox.pfui_skinned = true
+                end
+                if row.abilityDD and not row.abilityDD.pfui_skinned then
+                  StripTextures(row.abilityDD)
+                  SkinDropDown(row.abilityDD)
+                  row.abilityDD.pfui_skinned = true
+                end
+              end
+            end
+          end
+        end
+      end
+      
+      -- Hook OnShow after frames exist
+      HookOnShow("DoiteAurasFrame", SkinMainFrame)
+      HookOnShow("DoiteConditionsFrame", SkinEditFrame)
+      HookOnShow("DoiteAurasExportFrame", SkinExportFrame)
+      HookOnShow("DoiteAurasImportFrame", SkinImportFrame)
+      HookOnShow("DoiteAurasSettingsFrame", SkinSettingsFrame)
+    end
+  end)
+  
+  pfUI.addonskinner:UnregisterSkin("DoiteAuras")
+end)


### PR DESCRIPTION
Hi 
Adding two new addon skins to pfUI-addonskinner.

Both skins are working as intended.

DoiteAuras is fully functional, but it gave me a bit of a hard time during implementation and required some trial-and-error to get behaving correctly.

A lot of this was vibe-coded as I’m still learning my way around pfUI skinning, Lua and code in general. The end result works, but the code may not be as clean or optimal as it could be.

If you have the time, I’d really recommend a review and any changes or refactors you think would improve consistency, style. 

Thanks


Known Issue

In DoiteAuras, the aura edit menu has a visual issue where a light gray overlay remains on the drop down boxes.

I wasn’t able to remove this overlay without breaking the drop down functionality, so it’s currently left in place to avoid regressions.


<img width="973" height="658" alt="2026-02-08 22_28_16-World of Warcraft" src="https://github.com/user-attachments/assets/06e1febc-01b3-4b97-9cf8-d8786c3e2072" />


<img width="1046" height="714" alt="2026-02-08 22_28_38-World of Warcraft" src="https://github.com/user-attachments/assets/29295236-261c-43d9-aea0-725b9737d0e6" />


